### PR TITLE
uninstall unzip and wget from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN yum install unzip wget -y && \
     wget --no-verbose https://github.com/bitwarden/cli/releases/download/v1.22.1/bw-linux-1.22.1.zip && \
     unzip bw-linux-1.22.1.zip && \
     install bw /usr/local/bin/ && \
-    rm -rf bw*
+    rm -rf bw* && \
+    yum remove unzip wget -y
 ADD /target/Email.jar Email.jar
 ENTRYPOINT ["java","-jar","Email.jar"]


### PR DESCRIPTION
unzip and wget are only needed during the build, so they can be removed after docker build is complete