### PR TITLE
Get username from bitwarden

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An email inbox aggregator, supporting listing emails via IMAP from Gmail and AOL
 
 Run the docker image with environment variables for:
 ```
-accounts={'id|imap_hostname|username|bitwardenId','...'}
+accounts={'id|imap_hostname|bitwardenId','...'}
 bitwardenEmailFolderId=<get from bitwarden CLI, bw list folders>
 bitwardenCliLocation=<path to bitwarden CLI>
 BW_CLIENTID=<get from bitwarden vault>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.massaro</groupId>
     <artifactId>Email</artifactId>
-    <version>2.5</version>
+    <version>2.6</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/frontend/src/TableComponent.js
+++ b/src/frontend/src/TableComponent.js
@@ -112,14 +112,14 @@ class TableComponent extends Component {
                         });
 
                         failedAccounts.forEach((account) => {
-                            toast.error("Failed to sync: " + account.id, {
+                            toast.error("Failed to sync: " + account.username, {
                                 position: toast.POSITION.TOP_RIGHT,
                                 autoClose: false
                             });
                         });
 
                         partiallyFailedAccounts.forEach((account) => {
-                            toast.warn("Partially failed to sync (some messages may be missing): " + account.id, {
+                            toast.warn("Partially failed to sync (some messages may be missing): " + account.username, {
                                 position: toast.POSITION.TOP_RIGHT,
                                 autoClose: false
                             })
@@ -238,7 +238,7 @@ class TableComponent extends Component {
             '<span style="all:unset">' +
             '<b>From: </b><span>' + (email.fromPersonal ? (email.fromPersonal + " ") : "") + '&#8249;' + email.fromAddress + '&#8250;</span><br>' +
             '<b>Sent: </b>' + formatDate(new Date(email.dateReceived)) + '<br>' +
-            '<b>To: </b>' + email.toAddress + '<br>' +
+            '<b>To: </b>' + email.username + '<br>' +
             '<b>Subject: </b>' + email.subject +
             '<hr/><br></span>'
         );
@@ -286,7 +286,7 @@ class TableComponent extends Component {
                 Cell: row => {
                     return (
                         <span title={row.original.toAddress}>
-                            {row.original.account.username}
+                            {row.original.username}
                         </span>
                     )
                 }

--- a/src/frontend/src/TableComponent.js
+++ b/src/frontend/src/TableComponent.js
@@ -112,14 +112,14 @@ class TableComponent extends Component {
                         });
 
                         failedAccounts.forEach((account) => {
-                            toast.error("Failed to sync: " + account.username, {
+                            toast.error("Failed to sync: " + account.id, {
                                 position: toast.POSITION.TOP_RIGHT,
                                 autoClose: false
                             });
                         });
 
                         partiallyFailedAccounts.forEach((account) => {
-                            toast.warn("Partially failed to sync (some messages may be missing): " + account.username, {
+                            toast.warn("Partially failed to sync (some messages may be missing): " + account.id, {
                                 position: toast.POSITION.TOP_RIGHT,
                                 autoClose: false
                             })
@@ -238,7 +238,7 @@ class TableComponent extends Component {
             '<span style="all:unset">' +
             '<b>From: </b><span>' + (email.fromPersonal ? (email.fromPersonal + " ") : "") + '&#8249;' + email.fromAddress + '&#8250;</span><br>' +
             '<b>Sent: </b>' + formatDate(new Date(email.dateReceived)) + '<br>' +
-            '<b>To: </b>' + email.account.username + '<br>' +
+            '<b>To: </b>' + email.toAddress + '<br>' +
             '<b>Subject: </b>' + email.subject +
             '<hr/><br></span>'
         );

--- a/src/main/java/email/job/SyncJob.java
+++ b/src/main/java/email/job/SyncJob.java
@@ -36,7 +36,7 @@ public class SyncJob {
 
             List<Future<SyncStatusResult>> syncFutures = new ArrayList<>();
             for (Account account : accounts) {
-                log.debug("Submitting task for account {}", account.getUsername());
+                log.debug("Submitting task for account {}", account.getId());
                 syncFutures.add(syncService.sync(account, bitwardenMasterPassword));
             }
 

--- a/src/main/java/email/model/Account.java
+++ b/src/main/java/email/model/Account.java
@@ -12,7 +12,6 @@ public class Account {
     private long port;
     private String authentication;
     private String inboxName;
-    private String username;
     @JsonIgnore
     private UUID bitwardenItemId;
 }

--- a/src/main/java/email/model/Message.java
+++ b/src/main/java/email/model/Message.java
@@ -39,7 +39,14 @@ public class Message {
     private List<Address> recipient;
     private String fromAddress;
     private String fromPersonal;
+    /**
+     * The first recipient, in the recipient list, as defined by the IMAP server.
+     */
     private String toAddress;
+    /**
+     * The username of the account that this message was sent to, obtained from Bitwarden.
+     */
+    private String username;
     @JsonIgnore
     private List<BodyPart> bodyParts = new ArrayList<>();
     private boolean readInd;
@@ -53,7 +60,7 @@ public class Message {
 
     }
 
-    public Message(javax.mail.Message message, long uid, boolean alreadyExists) throws Exception {
+    public Message(javax.mail.Message message, long uid, boolean alreadyExists, String username) throws Exception {
         // only care to parse out the parts of the email for emails that are not in the database already
         // parsing is an expensive IMAP operation
         if (!alreadyExists) {
@@ -79,6 +86,7 @@ public class Message {
             if (ArrayUtils.isNotEmpty(recipients)) {
                 this.toAddress = recipients[0].toString();
             }
+            this.username = username;
         }
 
         this.uid = uid;

--- a/src/main/java/email/model/bitwarden/Login.java
+++ b/src/main/java/email/model/bitwarden/Login.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Login {
     private String password;
+    private String username;
 }

--- a/src/main/java/email/service/AccountService.java
+++ b/src/main/java/email/service/AccountService.java
@@ -23,8 +23,7 @@ public class AccountService {
 
             Account account = new Account();
             account.setId(Long.parseLong(accountStringSplit[0]));
-            account.setUsername(accountStringSplit[2]);
-            account.setBitwardenItemId(UUID.fromString(accountStringSplit[3]));
+            account.setBitwardenItemId(UUID.fromString(accountStringSplit[2]));
             account.setAuthentication("SSL");
             account.setHostname(accountStringSplit[1]);
             account.setInboxName("Inbox");

--- a/src/main/java/email/service/ImapService.java
+++ b/src/main/java/email/service/ImapService.java
@@ -5,6 +5,7 @@ import com.sun.mail.imap.IMAPFolder;
 import email.exception.SomeMessagesFailedToDownloadException;
 import email.model.Account;
 import email.model.Message;
+import email.model.bitwarden.Login;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.annotation.Async;
@@ -122,8 +123,8 @@ public class ImapService {
 
     private Store getStore(Message message) throws Exception {
         Account account = message.getAccount();
-        String password = bitwardenService.getPasswordFromCache(account.getBitwardenItemId());
-        return getStore(account.getHostname(), account.getPort(), account.getUsername(), password);
+        Login login = bitwardenService.getLoginFromCache(account.getBitwardenItemId());
+        return getStore(account.getHostname(), account.getPort(), login.getUsername(), login.getPassword());
     }
 
     private Store getStore(String hostname, long port, String username, String decryptedPassword) throws MessagingException {

--- a/src/main/java/email/service/ImapService.java
+++ b/src/main/java/email/service/ImapService.java
@@ -67,7 +67,7 @@ public class ImapService {
                     }
 
                     log.debug("Processing email {} of {} for {}", finalI + 1, messages.length, username);
-                    returnMessages.add(new Message(message, uid, messageAlreadyDownloaded));
+                    returnMessages.add(new Message(message, uid, messageAlreadyDownloaded, username));
                     return null; // this is useless, but is here to make this a callable, so that we can throw exceptions
                 });
 

--- a/src/test/java/email/service/BitwardenServiceTest.java
+++ b/src/test/java/email/service/BitwardenServiceTest.java
@@ -49,8 +49,10 @@ public class BitwardenServiceTest {
         Item one = items.get(0);
         assertEquals(UUID.fromString("d0f3b7f6-8fc5-41fa-9b4e-acd190ce21d1"), one.getId());
         assertEquals("crappypassword", one.getLogin().getPassword());
+        assertEquals("steveusername", one.getLogin().getUsername());
         Item two = items.get(1);
         assertEquals(UUID.fromString("8d607371-6e50-4802-845e-acd200ce21d1"), two.getId());
         assertEquals("mompassword", two.getLogin().getPassword());
+        assertEquals("momusername", two.getLogin().getUsername());
     }
 }


### PR DESCRIPTION
Get's the username for a particular accounts login from Bitwarden rather than from the user-supplied system settings.

Issues/notes:
- This has a breaking change to the format of the settings block (where the email accounts are actually defined)
- ~~I stopped working on this because I didn't like how there were places where we wouldn't have the account email, only the account ID. An example of this would be the logs when starting a sync (because we haven't gotten the username from bitwarden yet), or the informational messages that appear in the UI when a sync finishes.~~